### PR TITLE
Fix build: stop overwriting built index.html with dev version

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,9 +7,10 @@
     <title>דברים שענת אוהבת במיוחד</title>
     <!-- CRITICAL: DO NOT REMOVE/MODIFY THIS COMMENT OR THE SCRIPT BELOW -->
     <script src="https://blink.new/auto-engineer.js?projectId=anat-favorites-hub-id4aws1q" type="module"></script>
+    <script type="module" crossorigin src="/assets/index-2rxRa-yf.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-D170F4aG.css">
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html> 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && cp *.html docs/ 2>/dev/null; cp exercise.jpg docs/ 2>/dev/null; cp public/favicon.png public/favicon.svg docs/ 2>/dev/null; echo 'Build complete'",
+    "build": "vite build && for f in *.html; do [ \"$f\" != \"index.html\" ] && cp \"$f\" docs/; done 2>/dev/null; cp exercise.jpg docs/ 2>/dev/null; cp public/favicon.png public/favicon.svg docs/ 2>/dev/null; echo 'Build complete'",
     "build:vite": "vite build",
     "preview": "vite preview",
     "lint:css": "stylelint \"src/**/*.css\" --fix --quiet",


### PR DESCRIPTION
The build script was copying all *.html including index.html from root into docs/, overwriting Vite's properly built index.html that references the bundled JS/CSS assets.

https://claude.ai/code/session_01U8HbQhFow4nRsWVThxvKWL